### PR TITLE
[codex] Add button with select tool

### DIFF
--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -14,6 +14,8 @@ export const HELLO_WORLD_POST = "/code/posts/hello-world";
 export const MY_FIRST_REAL_VIBE_POST = "/code/posts/my-first-real-vibe";
 
 // NEW_USEFUL_TOOL: Useful tools and code section of routes
+export const BUTTON_WITH_SELECT_TOOL =
+  "/code/useful-tools-and-code/button-with-select";
 export const COLOR_CONVERTER_TOOL = "/code/useful-tools-and-code/color-converter";
 
 export const FOOD_HOME_PATH = "/food";

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -4,6 +4,7 @@ import {
   BeefStirFryScreen,
   BeerBatteredFishScreen,
   BlackBeanFlautasScreen,
+  ButtonWithSelectScreen,
   BraisedChickenScreen,
   CauliflowerHotWingsScreen,
   ChickenMarsalaScreen,
@@ -54,6 +55,7 @@ import {
   BEEF_SUKIYAKI_RICE_BOWL_RECIPE,
   BEER_BATTERED_FISH_RECIPE,
   BLACK_BEAN_FLAUTAS_RECIPE,
+  BUTTON_WITH_SELECT_TOOL,
   BRAISED_CHICKEN_RECIPE,
   CAULIFLOWER_HOT_WINGS_RECIPE,
   CHICKEN_MARSALA_RECIPE,
@@ -139,6 +141,10 @@ export const router = createBrowserRouter([
     element: <MyFirstRealVibeScreen />,
   },
   // NEW_USEFUL_TOOL: Useful tools and code section of routes... too.
+  {
+    path: BUTTON_WITH_SELECT_TOOL,
+    element: <ButtonWithSelectScreen />,
+  },
   {
     path: COLOR_CONVERTER_TOOL,
     element: <ColorConverterScreen />,

--- a/src/screens/code/useful-tools-and-code/UsefulToolsAndCodeHome.tsx
+++ b/src/screens/code/useful-tools-and-code/UsefulToolsAndCodeHome.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 
 import {
+  BUTTON_WITH_SELECT_TOOL,
   CODE_HOME_PATH,
   COLOR_CONVERTER_TOOL,
 } from "../../../routes/paths";
@@ -35,6 +36,12 @@ const usefulToolsAndCode: {
   title: string;
 }[] = [
   // NEW_USEFUL_TOOL: Useful tools and code section of preview data
+  {
+    category: UsefulToolCategory.Tool,
+    route: BUTTON_WITH_SELECT_TOOL,
+    teaser: "A split button with a default action and an accessible chooser.",
+    title: "Button with Select",
+  },
   {
     category: UsefulToolCategory.Tool,
     route: COLOR_CONVERTER_TOOL,

--- a/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelect.scss
+++ b/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelect.scss
@@ -33,6 +33,7 @@
     @include font-label-large;
 
     margin: 0 0 10px;
+    padding-top: 0;
   }
 
   p {
@@ -45,7 +46,11 @@
 .buttonWithSelectDemoPanel {
   @include themify($themes) {
     background:
-      linear-gradient(135deg, rgba(themed("brand-secondary"), 10%), transparent),
+      linear-gradient(
+        135deg,
+        rgba(themed("brand-secondary"), 10%),
+        transparent
+      ),
       themed("background");
     border-color: rgba(themed("border"), 92%);
   }
@@ -54,7 +59,7 @@
   border-radius: 18px;
   display: grid;
   gap: 16px;
-  justify-items: start;
+  place-items: center;
   padding: 20px;
 }
 
@@ -65,6 +70,7 @@
   }
 
   margin: 0;
+  text-align: center;
 }
 
 .buttonWithSelectNotes {
@@ -80,6 +86,7 @@
     @include font-label-large;
 
     margin: 0 0 10px;
+    padding-top: 0;
   }
 
   p {
@@ -130,7 +137,10 @@
     color: themed("on-brand");
   }
 
+  align-items: center;
   border-left: 1px solid;
+  display: inline-flex;
+  justify-content: center;
   padding: 0 14px;
 }
 
@@ -223,6 +233,7 @@
 }
 
 .buttonWithSelect-chevron {
+  display: block;
   fill: none;
   height: 18px;
   stroke: currentColor;
@@ -245,7 +256,7 @@
   }
 
   .buttonWithSelectDemoPanel {
-    justify-items: stretch;
+    min-height: 0;
   }
 
   .buttonWithSelect,

--- a/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelect.scss
+++ b/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelect.scss
@@ -1,0 +1,271 @@
+@import "../../../../../sass-mixins/fonts.scss";
+@import "../../../../../themes/theme-handler.scss";
+@import "../../../../../themes/themes.scss";
+
+.buttonWithSelectSurface {
+  display: grid;
+  gap: 20px;
+}
+
+.buttonWithSelectShowcase,
+.buttonWithSelectNoteCard {
+  @include themify($themes) {
+    background-color: themed("background");
+    border-color: rgba(themed("border"), 92%);
+    box-shadow:
+      0 12px 24px rgba(15, 23, 42, 6%),
+      0 2px 6px rgba(15, 23, 42, 4%);
+    color: themed("on-background");
+  }
+
+  border: 1px solid;
+  border-radius: 20px;
+}
+
+.buttonWithSelectShowcase {
+  display: grid;
+  gap: 18px;
+  padding: 24px;
+}
+
+.buttonWithSelectCopy {
+  h2 {
+    @include font-label-large;
+
+    margin: 0 0 10px;
+  }
+
+  p {
+    @include font-body-medium;
+
+    margin: 0;
+  }
+}
+
+.buttonWithSelectDemoPanel {
+  @include themify($themes) {
+    background:
+      linear-gradient(135deg, rgba(themed("brand-secondary"), 10%), transparent),
+      themed("background");
+    border-color: rgba(themed("border"), 92%);
+  }
+
+  border: 1px solid;
+  border-radius: 18px;
+  display: grid;
+  gap: 16px;
+  justify-items: start;
+  padding: 20px;
+}
+
+.buttonWithSelectStatus {
+  @include font-body-small;
+  @include themify($themes) {
+    color: rgba(themed("on-background"), 74%);
+  }
+
+  margin: 0;
+}
+
+.buttonWithSelectNotes {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.buttonWithSelectNoteCard {
+  padding: 20px;
+
+  h2 {
+    @include font-label-large;
+
+    margin: 0 0 10px;
+  }
+
+  p {
+    @include font-body-medium;
+
+    margin: 0;
+  }
+}
+
+.buttonWithSelect {
+  display: inline-flex;
+  position: relative;
+}
+
+.buttonWithSelect-control {
+  border-radius: 14px;
+  display: inline-flex;
+  overflow: hidden;
+}
+
+.buttonWithSelect-primary,
+.buttonWithSelect-toggle {
+  @include font-label-medium;
+
+  appearance: none;
+  border: 0;
+  cursor: pointer;
+  min-height: 48px;
+  transition:
+    background-color 0.15s ease,
+    transform 0.15s ease;
+}
+
+.buttonWithSelect-primary {
+  @include themify($themes) {
+    background-color: themed("brand-secondary");
+    color: themed("on-brand");
+  }
+
+  min-width: 210px;
+  padding: 0 18px;
+}
+
+.buttonWithSelect-toggle {
+  @include themify($themes) {
+    background-color: rgba(themed("brand-secondary"), 92%);
+    border-left-color: rgba(themed("on-brand"), 20%);
+    color: themed("on-brand");
+  }
+
+  border-left: 1px solid;
+  padding: 0 14px;
+}
+
+.buttonWithSelect-primary:hover,
+.buttonWithSelect-primary:focus-visible,
+.buttonWithSelect-toggle:hover,
+.buttonWithSelect-toggle:focus-visible {
+  @include themify($themes) {
+    background-color: themed("brand-secondary-hover");
+  }
+
+  outline: 0;
+}
+
+.buttonWithSelect-menu {
+  @include themify($themes) {
+    background-color: themed("background");
+    border-color: rgba(themed("border"), 94%);
+    box-shadow:
+      0 18px 32px rgba(15, 23, 42, 12%),
+      0 6px 14px rgba(15, 23, 42, 8%);
+  }
+
+  border: 1px solid;
+  border-radius: 16px;
+  display: grid;
+  gap: 8px;
+  min-width: min(320px, calc(100vw - 32px));
+  padding: 10px;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 10px);
+  z-index: 2;
+}
+
+.buttonWithSelect-option {
+  @include themify($themes) {
+    background-color: themed("background");
+    color: themed("on-background");
+  }
+
+  border: 0;
+  border-radius: 12px;
+  cursor: pointer;
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  text-align: left;
+  width: 100%;
+}
+
+.buttonWithSelect-option:hover,
+.buttonWithSelect-option:focus-visible {
+  @include themify($themes) {
+    background-color: themed("background-hover");
+  }
+
+  outline: 0;
+}
+
+.buttonWithSelect-option[aria-checked="true"] {
+  @include themify($themes) {
+    background-color: rgba(themed("brand-secondary"), 10%);
+  }
+}
+
+.buttonWithSelect-optionTitleRow {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.buttonWithSelect-optionTitle {
+  @include font-label-medium;
+}
+
+.buttonWithSelect-optionDescription {
+  @include font-body-small;
+  @include themify($themes) {
+    color: rgba(themed("on-background"), 72%);
+  }
+}
+
+.buttonWithSelect-selectedBadge {
+  @include font-label-small;
+
+  color: #3371ea;
+  white-space: nowrap;
+}
+
+.buttonWithSelect-chevron {
+  fill: none;
+  height: 18px;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.6;
+  width: 18px;
+}
+
+@media (max-width: 720px) {
+  .buttonWithSelectNotes {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .buttonWithSelectShowcase,
+  .buttonWithSelectNoteCard {
+    padding: 18px;
+  }
+
+  .buttonWithSelectDemoPanel {
+    justify-items: stretch;
+  }
+
+  .buttonWithSelect,
+  .buttonWithSelect-control {
+    display: flex;
+    width: 100%;
+  }
+
+  .buttonWithSelect-primary {
+    min-width: 0;
+  }
+
+  .buttonWithSelect-primary,
+  .buttonWithSelect-toggle {
+    justify-content: center;
+  }
+
+  .buttonWithSelect-menu {
+    left: 0;
+    min-width: 0;
+    right: 0;
+  }
+}

--- a/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelect.spec.tsx
+++ b/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelect.spec.tsx
@@ -1,0 +1,143 @@
+import { act } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import ButtonWithSelect from "./ButtonWithSelect";
+
+describe("ButtonWithSelect", () => {
+  test("runs the first action by default", async () => {
+    const firstAction = jest.fn();
+    const secondAction = jest.fn();
+
+    render(
+      <ButtonWithSelect
+        actions={[
+          {
+            title: "Preview component",
+            description: "Default preview action",
+            action: firstAction,
+          },
+          {
+            title: "Copy import path",
+            description: "Copy helper action",
+            action: secondAction,
+          },
+        ]}
+      />
+    );
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getByRole("button", { name: "Preview component" }),
+      );
+    });
+
+    expect(firstAction).toHaveBeenCalledTimes(1);
+    expect(secondAction).not.toHaveBeenCalled();
+  });
+
+  test("selects a different default action from the menu", async () => {
+    const firstAction = jest.fn();
+    const secondAction = jest.fn();
+
+    render(
+      <ButtonWithSelect
+        actions={[
+          {
+            title: "Preview component",
+            description: "Default preview action",
+            action: firstAction,
+          },
+          {
+            title: "Copy import path",
+            description: "Copy helper action",
+            action: secondAction,
+          },
+        ]}
+      />
+    );
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getByRole("button", { name: /choose action/i }),
+      );
+    });
+
+    expect(
+      screen.getByRole("menu", { name: "Available actions" }),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getByRole("menuitemradio", { name: /copy import path/i }),
+      );
+    });
+
+    expect(
+      screen.queryByRole("menu", { name: "Available actions" }),
+    ).not.toBeInTheDocument();
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getByRole("button", { name: "Copy import path" }),
+      );
+    });
+
+    expect(firstAction).not.toHaveBeenCalled();
+    expect(secondAction).toHaveBeenCalledTimes(1);
+  });
+
+  test("supports keyboard navigation when choosing an action", async () => {
+    const firstAction = jest.fn();
+    const secondAction = jest.fn();
+    const thirdAction = jest.fn();
+
+    render(
+      <ButtonWithSelect
+        actions={[
+          {
+            title: "Preview component",
+            description: "Default preview action",
+            action: firstAction,
+          },
+          {
+            title: "Copy import path",
+            description: "Copy helper action",
+            action: secondAction,
+          },
+          {
+            title: "Draft blog post",
+            description: "Draft helper action",
+            action: thirdAction,
+          },
+        ]}
+      />
+    );
+
+    screen.getByRole("button", { name: /choose action/i }).focus();
+
+    await act(async () => {
+      await userEvent.keyboard("{ArrowDown}");
+    });
+
+    const firstOption = screen.getByRole("menuitemradio", {
+      name: /preview component/i,
+    });
+
+    expect(firstOption).toHaveFocus();
+
+    await act(async () => {
+      await userEvent.keyboard("{ArrowDown}{Enter}");
+    });
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getByRole("button", { name: "Copy import path" }),
+      );
+    });
+
+    expect(firstAction).not.toHaveBeenCalled();
+    expect(secondAction).toHaveBeenCalledTimes(1);
+    expect(thirdAction).not.toHaveBeenCalled();
+  });
+});

--- a/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelect.spec.tsx
+++ b/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelect.spec.tsx
@@ -140,4 +140,70 @@ describe("ButtonWithSelect", () => {
     expect(secondAction).toHaveBeenCalledTimes(1);
     expect(thirdAction).not.toHaveBeenCalled();
   });
+
+  test("falls back to an in-range action when the actions array shrinks", async () => {
+    const firstAction = jest.fn();
+    const secondAction = jest.fn();
+    const thirdAction = jest.fn();
+
+    const { rerender } = render(
+      <ButtonWithSelect
+        actions={[
+          {
+            title: "Preview component",
+            description: "Default preview action",
+            action: firstAction,
+          },
+          {
+            title: "Copy import path",
+            description: "Copy helper action",
+            action: secondAction,
+          },
+          {
+            title: "Draft blog post",
+            description: "Draft helper action",
+            action: thirdAction,
+          },
+        ]}
+      />
+    );
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getByRole("button", { name: /choose action/i }),
+      );
+    });
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getByRole("menuitemradio", { name: /draft blog post/i }),
+      );
+    });
+
+    rerender(
+      <ButtonWithSelect
+        actions={[
+          {
+            title: "Preview component",
+            description: "Default preview action",
+            action: firstAction,
+          },
+        ]}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Preview component" }),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getByRole("button", { name: "Preview component" }),
+      );
+    });
+
+    expect(firstAction).toHaveBeenCalledTimes(1);
+    expect(secondAction).not.toHaveBeenCalled();
+    expect(thirdAction).not.toHaveBeenCalled();
+  });
 });

--- a/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelect.tsx
+++ b/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelect.tsx
@@ -56,25 +56,20 @@ function ButtonWithSelect(props: ButtonWithSelectProps) {
   const toggleButtonRef = useRef<HTMLButtonElement>(null);
   const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const menuId = useId();
+  const clampedSelectedIndex = clampSelectedIndex(actions.length, selectedIndex);
 
   useEffect(() => {
-    if (actions.length === 0) {
-      return;
+    if (selectedIndex !== clampedSelectedIndex) {
+      setSelectedIndex(clampedSelectedIndex);
     }
-
-    const maxIndex = actions.length - 1;
-
-    if (selectedIndex > maxIndex) {
-      setSelectedIndex(maxIndex);
-    }
-  }, [actions.length, selectedIndex]);
+  }, [clampedSelectedIndex, selectedIndex]);
 
   useEffect(() => {
     if (!isMenuOpen) {
       return;
     }
 
-    optionRefs.current[selectedIndex]?.focus();
+    optionRefs.current[clampedSelectedIndex]?.focus();
 
     function handlePointerDown(event: MouseEvent) {
       if (!containerRef.current?.contains(event.target as Node)) {
@@ -96,13 +91,13 @@ function ButtonWithSelect(props: ButtonWithSelectProps) {
       document.removeEventListener("mousedown", handlePointerDown);
       document.removeEventListener("keydown", handleDocumentKeyDown);
     };
-  }, [isMenuOpen, selectedIndex]);
+  }, [clampedSelectedIndex, isMenuOpen]);
 
   if (actions.length === 0) {
     return null;
   }
 
-  const selectedAction = actions[selectedIndex];
+  const selectedAction = actions[clampedSelectedIndex];
 
   function closeMenu(restoreToggleFocus = false) {
     setIsMenuOpen(false);
@@ -199,7 +194,7 @@ function ButtonWithSelect(props: ButtonWithSelectProps) {
         >
           {actions.map((action, index) => (
             <button
-              aria-checked={selectedIndex === index}
+              aria-checked={clampedSelectedIndex === index}
               className="buttonWithSelect-option"
               key={action.title}
               onClick={() => selectAction(index)}
@@ -214,7 +209,7 @@ function ButtonWithSelect(props: ButtonWithSelectProps) {
                 <span className="buttonWithSelect-optionTitle">
                   {action.title}
                 </span>
-                {selectedIndex === index && (
+                {clampedSelectedIndex === index && (
                   <span className="buttonWithSelect-selectedBadge">
                     Selected
                   </span>

--- a/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelect.tsx
+++ b/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelect.tsx
@@ -1,0 +1,234 @@
+import {
+  KeyboardEvent,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+
+import "./ButtonWithSelect.scss";
+
+export type ButtonWithSelectAction = {
+  action: () => void;
+  description: string;
+  title: string;
+};
+
+type ButtonWithSelectProps = {
+  actions: ButtonWithSelectAction[];
+  ariaLabel?: string;
+  initialSelectedIndex?: number;
+};
+
+function ChevronDownIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="buttonWithSelect-chevron"
+      viewBox="0 0 16 16"
+    >
+      <path d="M4 6.5 8 10l4-3.5" />
+    </svg>
+  );
+}
+
+function clampSelectedIndex(length: number, initialSelectedIndex: number) {
+  if (length === 0) {
+    return 0;
+  }
+
+  return Math.min(Math.max(initialSelectedIndex, 0), length - 1);
+}
+
+function ButtonWithSelect(props: ButtonWithSelectProps) {
+  const {
+    actions,
+    ariaLabel = "Split button actions",
+    initialSelectedIndex = 0,
+  } = props;
+  const safeInitialIndex = clampSelectedIndex(
+    actions.length,
+    initialSelectedIndex,
+  );
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(safeInitialIndex);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const toggleButtonRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const menuId = useId();
+
+  useEffect(() => {
+    if (actions.length === 0) {
+      return;
+    }
+
+    const maxIndex = actions.length - 1;
+
+    if (selectedIndex > maxIndex) {
+      setSelectedIndex(maxIndex);
+    }
+  }, [actions.length, selectedIndex]);
+
+  useEffect(() => {
+    if (!isMenuOpen) {
+      return;
+    }
+
+    optionRefs.current[selectedIndex]?.focus();
+
+    function handlePointerDown(event: MouseEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsMenuOpen(false);
+      }
+    }
+
+    function handleDocumentKeyDown(event: globalThis.KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsMenuOpen(false);
+        toggleButtonRef.current?.focus();
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleDocumentKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleDocumentKeyDown);
+    };
+  }, [isMenuOpen, selectedIndex]);
+
+  if (actions.length === 0) {
+    return null;
+  }
+
+  const selectedAction = actions[selectedIndex];
+
+  function closeMenu(restoreToggleFocus = false) {
+    setIsMenuOpen(false);
+
+    if (restoreToggleFocus) {
+      toggleButtonRef.current?.focus();
+    }
+  }
+
+  function openMenu() {
+    setIsMenuOpen(true);
+  }
+
+  function selectAction(index: number) {
+    setSelectedIndex(index);
+    closeMenu(true);
+  }
+
+  function moveFocus(nextIndex: number) {
+    optionRefs.current[nextIndex]?.focus();
+  }
+
+  function handleToggleButtonKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      openMenu();
+    }
+  }
+
+  function handleOptionKeyDown(
+    event: KeyboardEvent<HTMLButtonElement>,
+    optionIndex: number,
+  ) {
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        moveFocus((optionIndex + 1) % actions.length);
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        moveFocus((optionIndex - 1 + actions.length) % actions.length);
+        break;
+      case "Home":
+        event.preventDefault();
+        moveFocus(0);
+        break;
+      case "End":
+        event.preventDefault();
+        moveFocus(actions.length - 1);
+        break;
+      case "Tab":
+        closeMenu();
+        break;
+      default:
+        break;
+    }
+  }
+
+  return (
+    <div className="buttonWithSelect" ref={containerRef}>
+      <div
+        aria-label={ariaLabel}
+        className="buttonWithSelect-control"
+        role="group"
+      >
+        <button
+          className="buttonWithSelect-primary"
+          onClick={selectedAction.action}
+          type="button"
+        >
+          {selectedAction.title}
+        </button>
+        <button
+          aria-controls={menuId}
+          aria-expanded={isMenuOpen}
+          aria-haspopup="menu"
+          aria-label={`Choose action. Current action ${selectedAction.title}`}
+          className="buttonWithSelect-toggle"
+          onClick={() => setIsMenuOpen((isOpen) => !isOpen)}
+          onKeyDown={handleToggleButtonKeyDown}
+          ref={toggleButtonRef}
+          type="button"
+        >
+          <ChevronDownIcon />
+        </button>
+      </div>
+
+      {isMenuOpen && (
+        <div
+          aria-label="Available actions"
+          className="buttonWithSelect-menu"
+          id={menuId}
+          role="menu"
+        >
+          {actions.map((action, index) => (
+            <button
+              aria-checked={selectedIndex === index}
+              className="buttonWithSelect-option"
+              key={action.title}
+              onClick={() => selectAction(index)}
+              onKeyDown={(event) => handleOptionKeyDown(event, index)}
+              ref={(node) => {
+                optionRefs.current[index] = node;
+              }}
+              role="menuitemradio"
+              type="button"
+            >
+              <span className="buttonWithSelect-optionTitleRow">
+                <span className="buttonWithSelect-optionTitle">
+                  {action.title}
+                </span>
+                {selectedIndex === index && (
+                  <span className="buttonWithSelect-selectedBadge">
+                    Selected
+                  </span>
+                )}
+              </span>
+              <span className="buttonWithSelect-optionDescription">
+                {action.description}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ButtonWithSelect;

--- a/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelectScreen.tsx
+++ b/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelectScreen.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+
+import UsefulToolWrapper from "../../UsefulToolWrapper";
+import { UsefulToolCategory } from "../../UsefulToolsAndCodeHome";
+import ButtonWithSelect, {
+  ButtonWithSelectAction,
+} from "./ButtonWithSelect";
+
+function ButtonWithSelectScreen() {
+  const [lastTriggeredAction, setLastTriggeredAction] = useState(
+    "Use the main button to run the current default action.",
+  );
+
+  const demoActions: ButtonWithSelectAction[] = [
+    {
+      title: "Preview component",
+      description: "Run the default preview flow without opening the chooser.",
+      action: () => setLastTriggeredAction("Ran: Preview component."),
+    },
+    {
+      title: "Copy import path",
+      description: "Swap the default action to a quick copy-oriented workflow.",
+      action: () => setLastTriggeredAction("Ran: Copy import path."),
+    },
+    {
+      title: "Draft blog post",
+      description: "Switch to the action that starts writing the companion post.",
+      action: () => setLastTriggeredAction("Ran: Draft blog post."),
+    },
+  ];
+
+  return (
+    <UsefulToolWrapper
+      category={UsefulToolCategory.Tool}
+      subTitle="A split button keeps one fast default action while letting people choose a different one."
+      title="Button with Select"
+    >
+      <div className="buttonWithSelectSurface">
+        <section className="buttonWithSelectShowcase">
+          <div className="buttonWithSelectCopy">
+            <h2>Demo</h2>
+            <p>
+              The left button always runs the current default action. The right
+              button opens a small chooser where each option has a title and
+              supporting description.
+            </p>
+          </div>
+
+          <div className="buttonWithSelectDemoPanel">
+            <ButtonWithSelect actions={demoActions} />
+            <p className="buttonWithSelectStatus" role="status">
+              {lastTriggeredAction}
+            </p>
+          </div>
+        </section>
+
+        <section className="buttonWithSelectNotes">
+          <article className="buttonWithSelectNoteCard">
+            <h2>Why this pattern works</h2>
+            <p>
+              It looks like a single control, but it stays semantically honest:
+              one button executes an action and the adjacent button chooses
+              which action that is.
+            </p>
+          </article>
+
+          <article className="buttonWithSelectNoteCard">
+            <h2>Accessibility details</h2>
+            <p>
+              The control uses a labeled button group, a menu button with
+              `aria-expanded`, and radio-style menu items so the current default
+              action is discoverable with both keyboard and screen readers.
+            </p>
+          </article>
+        </section>
+      </div>
+    </UsefulToolWrapper>
+  );
+}
+
+export default ButtonWithSelectScreen;

--- a/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelectScreen.tsx
+++ b/src/screens/code/useful-tools-and-code/content/button-with-select/ButtonWithSelectScreen.tsx
@@ -2,9 +2,7 @@ import { useState } from "react";
 
 import UsefulToolWrapper from "../../UsefulToolWrapper";
 import { UsefulToolCategory } from "../../UsefulToolsAndCodeHome";
-import ButtonWithSelect, {
-  ButtonWithSelectAction,
-} from "./ButtonWithSelect";
+import ButtonWithSelect, { ButtonWithSelectAction } from "./ButtonWithSelect";
 
 function ButtonWithSelectScreen() {
   const [lastTriggeredAction, setLastTriggeredAction] = useState(
@@ -24,7 +22,8 @@ function ButtonWithSelectScreen() {
     },
     {
       title: "Draft blog post",
-      description: "Switch to the action that starts writing the companion post.",
+      description:
+        "Switch to the action that starts writing the companion post.",
       action: () => setLastTriggeredAction("Ran: Draft blog post."),
     },
   ];
@@ -32,7 +31,7 @@ function ButtonWithSelectScreen() {
   return (
     <UsefulToolWrapper
       category={UsefulToolCategory.Tool}
-      subTitle="A split button keeps one fast default action while letting people choose a different one."
+      subTitle="A split button keeps one fast default action while letting people choose a different action if desired."
       title="Button with Select"
     >
       <div className="buttonWithSelectSurface">

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -20,6 +20,7 @@ import HelloWorldScreen from "./code/posts/content/HelloWorld";
 import MyFirstRealVibeScreen from "./code/posts/content/MyFirstRealVibe";
 
 // NEW_USEFUL_TOOL: Useful tools and code section of imports
+import ButtonWithSelectScreen from "./code/useful-tools-and-code/content/button-with-select/ButtonWithSelectScreen";
 import ColorConverterScreen from "./code/useful-tools-and-code/content/color-converter/ColorConverter";
 
 import FoodHomeScreen from "./food/FoodHome";
@@ -77,6 +78,7 @@ export {
   HelloWorldScreen,
   MyFirstRealVibeScreen,
   // NEW_USEFUL_TOOL: Useful tools and code section of screens
+  ButtonWithSelectScreen,
   ColorConverterScreen,
   // NEW_RECIPE: Recipes section of screens
   BeefNegimakiScreen,


### PR DESCRIPTION
## Summary
- add a new "Button with Select" useful tool page with a reusable split-button component
- wire the tool into routes, screen exports, and the Useful Tools & Code index
- add focused tests for the default action, action selection, and keyboard behavior

## Verification
- `npm test -- --watchAll=false`
- `npm run build`

Closes #11